### PR TITLE
Version 2.0 Migrating to Internal database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ go.work.sum
 # env file
 .env
 dist
+kscribbler.sqlite

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ I would like to make this over-the-air (OTA) updatable in the future, but the wa
 ## Usage
 
 Once installed `nickelmenu` should have a new entry in the right corner of reading view that will trigger a sync when clicked.
-To save some battery and resources the sync is only ran against the current/last opened book.
+
+This will trigger `kscribbler` to generate its database of quotes and upload them to hardcover.app.
+WARNING: This will attempt to upload all quotes from all books on the device. If you want to tame this you will need to manipulate the `kscribblerdb` yourself. More info below.
 
 The quotes are uploaded to hardcover.app based on the book's ISBN. See the note below or the troubleshooting section if quotes are not being uploaded.
 
@@ -44,13 +46,20 @@ The quotes are uploaded to hardcover.app based on the book's ISBN. See the note 
 ## Troubleshooting
 - Logs are stored in `/mnt/onboard/.adds/kscribbler/kscribbler.log`
 - If you are having issues with the quotes not being uploaded, check that hardcover.app has an edition for the ISBN.
-- This project depends on the `KoboReader.sqlite` database to be up to date. This typically means a successful sync is required for the DB to actually write from memory to disk.
-  - This leads to some annoying timing issues. I would recommend running the program after a sync and reboot if you are having trouble uploading quotes.
-- For the savvy the sqlite db is located at`/mnt/onboard/.kobo/KoboReader.sqlite`
-  - You can modify this database to add an ISBN to a book if you know what you're doing
-  - `telnet/ssh` into the kobo is possible and allows for manually running `kscribbler` if so desired
+
+## Advanced Usage
+- The database of quotes is stored at `/mnt/onboard/.adds/kscribbler/kscribblerdb`
+- This is a sqlite database with two tables: `books` and `quotes`
+- You can manipulate this database directly if you want to control what gets uploaded by setting `kscribbler_uploaded` to `1` for quotes you don't want uploaded
+- `telnet/ssh` into the kobo is possible and allows for manually running `kscribbler` if so desired
+- From the command line you can run `kscribbler --help` to see available options
+  - `kscribbler --init` will initialize the database but not upload anything
+  - `kscribbler --mark-all-as-uploaded` will initialize the database, mark all found quotes as upload but will not upload anything
+    - Useful for testing/migrating
+
 
 ## Contributing
+- Star the repository ⭐
 - File bug reports
 - Submit pull requests
 - Suggest improvements

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -151,7 +151,25 @@ func loadQuotesFromDB() ([]Bookmark, error) {
 	return quotes, nil
 }
 
-// also do this with hardover ids
+func updateDBWithHardcoverInfo() {
+
+	var books []Book
+	//TODO: check this
+	err := kscribblerDB.Select(
+		&books,
+		`SELECT isbn FROM book WHERE hardcover_id OR hardcover_edition IS NULL;`,
+	)
+
+	if err != nil {
+		log.Printf("failed to load books with missing hardcover info: %w", err)
+	}
+
+	for _, book := range books {
+		book.koboToHardcover()
+	}
+
+}
+
 // loop through all books with missing isbns and try to populate them from their quotes
 func updateDBWithISBNs() {
 

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -14,7 +14,7 @@ import (
 
 var kscribblerDB *sqlx.DB
 var koboDBPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
-var kscribblerDBPath = "/mnt/onboard/.adds/kscribbler.sqlite"
+var kscribblerDBPath = "/mnt/onboard/.adds/kscribbler/kscribbler.sqlite"
 
 // connectKscribblerDB connects to the kscribbler SQLite database and creates it if it doesn't exist.
 func connectKscribblerDB() *sqlx.DB {
@@ -43,6 +43,7 @@ func connectDatabases() *sqlx.DB {
 // createKscribblerTables creates the SQLite database if it doesn't exist.
 func createKscribblerTables() {
 	if _, err := os.Stat(kscribblerDBPath); err == nil {
+		log.Printf("kscribblerDB already exists at %s, skipping creation", kscribblerDBPath)
 		return
 	} else if !errors.Is(err, os.ErrNotExist) {
 		log.Fatalf("Error while trying to create/open kscribblerDB: %v", err)

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -12,13 +12,13 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var db *sqlx.DB
-var kobodbPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
-var kscribblerdbPath = "/mnt/onboard/.adds/kscribbler.sqlite"
+var koboDB *sqlx.DB
+var koboDBPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
+var kscribblerDBPath = "/mnt/onboard/.adds/kscribbler.sqlite"
 
 // createKscribblerDB creates the SQLite database file if it doesn't exist
 func createKscribblerDB() error {
-	if _, err := os.Stat(kscribblerdbPath); err == nil {
+	if _, err := os.Stat(kscribblerDBPath); err == nil {
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		log.Fatal(err)
@@ -26,7 +26,7 @@ func createKscribblerDB() error {
 	}
 
 	// File does not exist, create the database
-	db, err := sql.Open("sqlite3", kscribblerdbPath)
+	db, err := sql.Open("sqlite3", kscribblerDBPath)
 	if err != nil {
 		return err
 	}
@@ -47,17 +47,28 @@ func createKscribblerDB() error {
 
 	// Quotes table
 	_, err = db.Exec(`
-    CREATE TABLE IF NOT EXISTS quotes (
+    CREATE TABLE IF NOT EXISTS quote (
         book_id INTEGER NOT NULL,
         quote TEXT NOT NULL,
         page INTEGER,
+		hardcover_id TEXT,
         FOREIGN KEY(book_id) REFERENCES book(id),
-        hardcover_id REFERENCES book(hardcover_id)
+        FOREIGN KEY(hardcover_id) REFERENCES book(hardcover_id)
     )
 `)
 	if err != nil {
 		log.Fatalf("failed to create quotes table: %v", err)
 	}
+
+	return nil
+}
+
+func populateKscribblerDB() error {
+	ksdb, err := sql.Open("sqlite3", kscribblerDBPath)
+	if err != nil {
+		return err
+	}
+	defer ksdb.Close()
 
 	return nil
 }

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -203,9 +203,7 @@ func updateDBWithISBNs() {
 			continue
 		}
 		book.Bookmarks = quotes
-		if !book.SetIsbnFromBook() {
-			continue
-		}
+		book.SetIsbnFromBook()
 	}
 
 	log.Println("Updated missing ISBNs in book table")

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -20,11 +20,11 @@ var kscribblerDBPath = "/mnt/onboard/.adds/kscribbler.sqlite"
 
 // connectKscribblerDB connects to the kscribbler SQLite database and creates it if it doesn't exist.
 func connectKscribblerDB() *sqlx.DB {
-	dbErrMsG := "failed to open database at %s: %w"
+	dbErrMsg := "failed to open database at %s: %w"
 
 	kscribblerDB, err := sqlx.Open("sqlite3", kscribblerDBPath)
 	if err != nil {
-		err := fmt.Errorf(dbErrMsG, kscribblerDBPath, err)
+		err := fmt.Errorf(dbErrMsg, kscribblerDBPath, err)
 		log.Fatal(err.Error())
 	}
 	return kscribblerDB

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -30,7 +30,7 @@ func connectKscribblerDB() *sqlx.DB {
 	return kscribblerDB
 }
 
-// Read kobosqlite and populate kscribbler sqlite with relevant data
+// connectDatabases attaches kscribblerDB to KoboReaderDB in order to populate kscribblerDB with relevant data.
 func connectDatabases() *sqlx.DB {
 	kscribblerDB := connectKscribblerDB()
 	// attach to kobo database also
@@ -42,7 +42,7 @@ func connectDatabases() *sqlx.DB {
 	return kscribblerDB
 }
 
-// createKscribblerTables creates the SQLite database file if it doesn't exist
+// createKscribblerTables creates the SQLite database if it doesn't exist.
 func createKscribblerTables() {
 	if _, err := os.Stat(kscribblerDBPath); err == nil {
 		return
@@ -86,6 +86,7 @@ func createKscribblerTables() {
 
 }
 
+// populateQuoteTable populates the quote table in kscribblerDB with quotes and annotations from KoboReader.sqlite.
 func populateQuoteTable() {
 	kscribblerDB := connectDatabases()
 	defer kscribblerDB.Close()
@@ -107,6 +108,7 @@ func populateQuoteTable() {
 	}
 }
 
+// populateBookTable populates the book table in kscribblerDB with book identifiers from KoboReader.sqlite.
 func populateBookTable() {
 	kscribblerDB := connectDatabases()
 	defer kscribblerDB.Close()
@@ -125,6 +127,7 @@ func populateBookTable() {
 	}
 }
 
+// loadQuotesFromDB loads quotes and annotations from the kscribblerDB that have not been uploaded yet.
 func loadQuotesFromDB() ([]Bookmark, error) {
 	var quotes []Bookmark
 	err := kscribblerDB.Select(&quotes, `
@@ -144,6 +147,7 @@ func loadQuotesFromDB() ([]Bookmark, error) {
 	return quotes, nil
 }
 
+// updateDBWithHardcoverInfo updates the kscribblerDB with missing hardcover info from Hardcover API.
 func updateDBWithHardcoverInfo() {
 
 	var books []Book
@@ -191,7 +195,7 @@ func updateDBWithHardcoverInfo() {
 	log.Println("Updated missing Hardcover info in book table")
 }
 
-// loop through all books with missing isbns and try to populate them from their quotes
+// updateDBWithISBNs loops through all books with missing isbns and tries to populate them from their quotes and annotations.
 func updateDBWithISBNs() {
 
 	var books []Book
@@ -220,7 +224,7 @@ func updateDBWithISBNs() {
 	// also want to make sure isbn 13 is stored
 }
 
-// loadBooksFromDB loads books with pending quotes from the kscribbler database
+// loadBooksFromDB loads books with pending quotes from the kscribbler database.
 func loadBooksFromDB() []Book {
 	var books []Book
 

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -163,12 +163,11 @@ func updateDBWithHardcoverInfo() {
 		//isbn 13 is breaking with 1230004555278 (silent spring)
 		// 1230004555278 is not valid
 		isbn, err := simpleISBN.NewISBN(book.FoundISBN.String)
-		book.SimpleISBN = *isbn
-
 		if err != nil {
 			log.Printf("failed to parse isbn %s: %v", book.FoundISBN.String, err)
 			continue
 		}
+		book.SimpleISBN = *isbn
 
 		book.koboToHardcover()
 		if book.SimpleISBN.ISBN10Number == "" && book.SimpleISBN.ISBN13Number == "" {

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"log"
+
+	"database/sql"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var db *sqlx.DB
+var kobodbPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
+var kscribblerdbPath = "/mnt/onboard/.adds/kscribbler.sqlite"
+
+// createKscribblerDB creates the SQLite database file if it doesn't exist
+func createKscribblerDB() error {
+	if _, err := os.Stat(kscribblerdbPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		log.Fatal(err)
+		return err
+	}
+
+	// File does not exist, create the database
+	db, err := sql.Open("sqlite3", kscribblerdbPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+    CREATE TABLE IF NOT EXISTS book (
+        id TEXT PRIMARY KEY NOT NULL,
+        book_title TEXT NOT NULL,
+		isbn TEXT,
+		hardcover_id TEXT, 
+		kscribbler_uploaded INTEGER DEFAULT 0
+    )
+`)
+	if err != nil {
+		log.Fatalf("failed to create book table: %v", err)
+	}
+
+	// Quotes table
+	_, err = db.Exec(`
+    CREATE TABLE IF NOT EXISTS quotes (
+        book_id INTEGER NOT NULL,
+        quote TEXT NOT NULL,
+        page INTEGER,
+        FOREIGN KEY(book_id) REFERENCES book(id),
+        hardcover_id REFERENCES book(hardcover_id)
+    )
+`)
+	if err != nil {
+		log.Fatalf("failed to create quotes table: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/GianniBYoung/simpleISBN"
-	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -21,7 +20,7 @@ var kscribblerDBPath = "/mnt/onboard/.adds/kscribbler.sqlite"
 func connectKscribblerDB() *sqlx.DB {
 	dbErrMsg := "failed to open database at %s: %w"
 
-	kscribblerDB, err := sqlx.Open("sqlite3", kscribblerDBPath)
+	kscribblerDB, err := sqlx.Open("sqlite", kscribblerDBPath)
 	if err != nil {
 		err := fmt.Errorf(dbErrMsg, kscribblerDBPath, err)
 		log.Fatal(err.Error())

--- a/cmd/kscribbler/db.go
+++ b/cmd/kscribbler/db.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var koboDB *sqlx.DB
 var kscribblerDB *sqlx.DB
 var koboDBPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
 var kscribblerDBPath = "/mnt/onboard/.adds/kscribbler.sqlite"

--- a/cmd/kscribbler/http.go
+++ b/cmd/kscribbler/http.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
-	"fmt"
+	"log"
 	"net/http"
 )
 
@@ -16,22 +16,22 @@ var hardcoverCert []byte
 const apiURL = "https://api.hardcover.app/v1/graphql"
 
 // http client with embedded CA bundle for api.hardcover.app
-func newHTTPClient() (*http.Client, error) {
+func newHTTPClient() *http.Client {
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(hardcoverCert) {
-		return nil, fmt.Errorf("failed to parse embedded CA bundle")
+		log.Fatalf("failed to parse embedded CA bundle... exiting")
 	}
 	tlsConfig := &tls.Config{
 		RootCAs: pool,
 	}
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	return &http.Client{Transport: transport}, nil
+	return &http.Client{Transport: transport}
 }
 
-func newHardcoverRequest(ctx context.Context, body []byte) (*http.Request, error) {
+func newHardcoverRequest(ctx context.Context, body []byte) *http.Request {
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(body))
 	if err != nil {
-		return nil, err
+		log.Fatalf("Failed to create newHardcoverRequest: %v", err)
 	}
 
 	req.Header.Set("Authorization", authToken)
@@ -41,5 +41,5 @@ func newHardcoverRequest(ctx context.Context, body []byte) (*http.Request, error
 		"kscribbler - https://github.com/GianniBYoung/kscribbler",
 	)
 
-	return req, nil
+	return req
 }

--- a/cmd/kscribbler/http.go
+++ b/cmd/kscribbler/http.go
@@ -15,7 +15,7 @@ var hardcoverCert []byte
 
 const apiURL = "https://api.hardcover.app/v1/graphql"
 
-// http client with embedded CA bundle for api.hardcover.app
+// newHTTPClient with embedded CA bundle for api.hardcover.app
 func newHTTPClient() *http.Client {
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(hardcoverCert) {
@@ -28,6 +28,7 @@ func newHTTPClient() *http.Client {
 	return &http.Client{Transport: transport}
 }
 
+// newHardcoverRequest creates a new HTTP request to the Hardcover API with the appropriate headers.
 func newHardcoverRequest(ctx context.Context, body []byte) *http.Request {
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(body))
 	if err != nil {

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -29,11 +29,11 @@ func (book Book) String() string {
 
 	result += "\n========== Book ==========\n"
 	result += fmt.Sprintf("Title: %s\n", book.Title.String)
-	result += fmt.Sprintf("ContentID: %s\n", book.BookID)
+	result += fmt.Sprintf("BookID: %s\n", book.BookID)
 	result += fmt.Sprintf("ISBN: %s", book.ISBN)
 
 	result += "\n===== Hardcover Info =====\n"
-	result += fmt.Sprintf("BookID: %d\n", book.Hardcover.BookID)
+	result += fmt.Sprintf("HardcoverID: %d\n", book.Hardcover.BookID)
 	result += fmt.Sprintf("EditionID: %d\n", book.Hardcover.EditionID)
 
 	result += "\n======== Bookmarks ========\n"
@@ -71,7 +71,7 @@ func (b *Book) SetIsbnFromBook() (error, bool) {
 	isbn10Regex := regexp.MustCompile(`[0-9][-0-9]{8,12}[0-9Xx]`)
 	isbn13Regex := regexp.MustCompile(`97[89][-0-9]{10,16}`)
 
-	for i, bm := range b.Bookmarks {
+	for _, bm := range b.Bookmarks {
 		if !bm.Annotation.Valid ||
 			!strings.Contains(bm.Annotation.String, strings.ToLower("kscrib:")) {
 			continue
@@ -282,7 +282,7 @@ func (entry Bookmark) postEntry(
 	if entry.Type == "note" {
 		hardcoverType = "annotation"
 		entryText = fmt.Sprintf("%s\n\n============\n\n%s", quote, annotation)
-		fmt.Println(
+		log.Println(
 			"Skipping annotation upload until hardcover's api has better multiline support",
 			entryText,
 		)

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -19,6 +19,7 @@ import (
 
 var authToken string
 var stopAfterInit bool
+var markAllAsUploaded bool
 
 // TODO: Think about a more efficient query so i don't hammer the api
 // fleshes out struct and assocites book to hardcover
@@ -227,11 +228,31 @@ func init() {
 
 func main() {
 	flag.BoolVar(&stopAfterInit, "init", false, "Stop execution after init() runs")
+	flag.BoolVar(
+		&markAllAsUploaded,
+		"mark-all-as-uploaded",
+		false,
+		"Mark all quotes in the database as uploaded (useful for migration)",
+	)
 	flag.Parse()
 	if stopAfterInit {
 		log.Println(
 			"The init flag was set; stopping execution after database initialization. Quotes will not be uploaded.",
 		)
+		os.Exit(0)
+	}
+
+	if markAllAsUploaded {
+		log.Println(
+			"The mark-all-as-uploaded flag was set; marking all quotes in kscribblerDB as uploaded. Quotes will not be uploaded.",
+		)
+		kscribblerDB = connectKscribblerDB()
+		_, err := kscribblerDB.Exec(` UPDATE quote SET kscribbler_uploaded = 1;`)
+
+		if err != nil {
+			log.Fatalf("failed to mark all quotes as uploaded in kscribblerDB: %v", err)
+		}
+		log.Println("All quotes marked as uploaded. Exiting.")
 		os.Exit(0)
 	}
 

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -35,7 +35,6 @@ func (book Book) String() string {
 	result += "\n===== Hardcover Info =====\n"
 	result += fmt.Sprintf("BookID: %d\n", book.Hardcover.BookID)
 	result += fmt.Sprintf("EditionID: %d\n", book.Hardcover.EditionID)
-	result += fmt.Sprintf("PrivacyLevel: %d\n", book.Hardcover.PrivacyLevel)
 
 	result += "\n======== Bookmarks ========\n"
 	for i, bm := range book.Bookmarks {
@@ -267,7 +266,6 @@ func (entry Bookmark) postEntry(
 	ctx context.Context,
 	hardcoverID int,
 	spoiler bool,
-	privacyLevel PrivacyLevel,
 ) error {
 	isUploaded, err := entry.hasBeenUploaded(koboDB)
 	if err != nil {
@@ -304,13 +302,13 @@ func (entry Bookmark) postEntry(
 	mutation := fmt.Sprintf(`
 	mutation postquote {
     insert_reading_journal(
-    object: {book_id: %d, event: "%s", tags: {spoiler: %t, category: "%s", tag: ""}, entry: """%s""", privacy_setting_id: %d}
+    object: {book_id: %d, event: "%s", tags: {spoiler: %t, category: "%s", tag: ""}, entry: """%s""" }
      ) {
     errors
   }
 }`,
 		hardcoverID, hardcoverType, spoiler,
-		hardcoverType, entryText, privacyLevel)
+		hardcoverType, entryText)
 
 	reqBody := map[string]string{"query": mutation}
 	bodyBytes, _ := json.Marshal(reqBody)
@@ -387,7 +385,6 @@ func main() {
 	// 		ctx,
 	// 		currentBook.Hardcover.BookID,
 	// 		false,
-	// 		currentBook.Hardcover.PrivacyLevel,
 	// 	)
 	//
 	// 	if err != nil {

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -23,7 +23,7 @@ import (
 var db *sqlx.DB
 var currentBook Book
 var authToken string
-var dbPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
+var kobodbPath = "/mnt/onboard/.kobo/KoboReader.sqlite"
 
 // Print info about the book and its bookmarks
 func (b Book) String() string {
@@ -366,11 +366,11 @@ func init() {
 	}
 
 	if devDBPath := os.Getenv("KSCRIBBLER_DB_PATH"); devDBPath != "" {
-		dbPath = devDBPath
+		kobodbPath = devDBPath
 	}
 
 	var err error
-	db, err = sqlx.Open("sqlite", dbPath)
+	db, err = sqlx.Open("sqlite", kobodbPath)
 
 	if err != nil {
 		log.Print("Error opening database")

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -31,7 +31,6 @@ func (book *Book) koboToHardcover() {
 	}
 
 	ctx := context.Background()
-
 	client := newHTTPClient()
 
 	var filters []string
@@ -124,18 +123,18 @@ func (bm Bookmark) hasBeenUploaded() bool {
 	return isUploaded != 0
 }
 
-func (bm Bookmark) markAsUploaded() error {
+func (bm Bookmark) markAsUploaded() {
 	log.Printf("Marking bookmark %s as uploaded", bm.BookmarkID)
 	_, err := kscribblerDB.Exec(`
 		UPDATE quote
 		SET kscribbler_uploaded = 1
 		WHERE bookmark_id = ?;
 	`, bm.BookmarkID)
-	log.Printf("Marked bookmark %s as uploaded", bm.BookmarkID)
+
 	if err != nil {
-		return fmt.Errorf("failed to mark bookmark as uploaded: %w", err)
+		log.Fatalf("failed to mark bookmark as uploaded: %v", err)
 	}
-	return nil
+	log.Printf("Marked bookmark %s as uploaded", bm.BookmarkID)
 }
 
 func (entry Bookmark) postEntry(
@@ -190,10 +189,7 @@ func (entry Bookmark) postEntry(
 
 	rawResp, _ := io.ReadAll(resp.Body)
 	fmt.Println("Hardcover response:", string(rawResp))
-	err = entry.markAsUploaded()
-	if err != nil {
-		log.Printf("Failed to mark entry as uploaded in kscribblerDB: %v", err)
-	}
+	entry.markAsUploaded()
 
 	return nil
 }
@@ -265,5 +261,5 @@ func main() {
 		}
 		log.Printf("Finished uploading bookmarks for book: %s\n", currentBook.Title.String)
 	}
-
+	log.Println("Job done!")
 }

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -21,9 +21,9 @@ var authToken string
 var stopAfterInit bool
 var markAllAsUploaded bool
 
-// TODO: Think about a more efficient query so i don't hammer the api
-// fleshes out struct and assocites book to hardcover
+// koboToHardcover fleshes out struct and assocites book to hardcover.
 func (book *Book) koboToHardcover() {
+	// TODO: Think about a more efficient query so i don't hammer the api
 
 	// this also assumes a valid isbn already
 	if book.SimpleISBN.ISBN10Number == "" && book.SimpleISBN.ISBN13Number == "" {
@@ -109,6 +109,7 @@ func (book *Book) koboToHardcover() {
 
 }
 
+// hasBeenUploaded checks if the bookmark has already been uploaded to Hardcover by querying the kscribblerDB.
 func (bm Bookmark) hasBeenUploaded() bool {
 	var isUploaded int
 
@@ -125,6 +126,7 @@ func (bm Bookmark) hasBeenUploaded() bool {
 	return isUploaded != 0
 }
 
+// markAsUploaded updates the kscribblerDB to mark the quote as uploaded.
 func (bm Bookmark) markAsUploaded() {
 	log.Printf("Marking bookmark %s as uploaded", bm.BookmarkID)
 	_, err := kscribblerDB.Exec(`
@@ -139,6 +141,7 @@ func (bm Bookmark) markAsUploaded() {
 	log.Printf("Marked bookmark %s as uploaded", bm.BookmarkID)
 }
 
+// postEntry uploads the bookmark (quote or annotation) to Hardcover using their GraphQL API.
 func (entry Bookmark) postEntry(
 	client *http.Client,
 	ctx context.Context,

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -341,33 +341,7 @@ func init() {
 	}
 
 	var err error
-	koboDB, err = sqlx.Open("sqlite", koboDBPath)
-	if err != nil {
-		err := fmt.Errorf("failed to open database at %s: %w", koboDBPath, err)
-		log.Print(err.Error())
-		log.Fatal(err)
-	}
-	defer koboDB.Close()
 
-	// cidquery := `
-	// 	SELECT c.ContentID, c.ISBN, c.Title
-	// 	FROM content c
-	// 	WHERE c.ContentType = 6
-	// 		AND c.DateLastRead IS NOT NULL
-	// 	ORDER BY c.DateLastRead DESC
-	// 	LIMIT 1;
-	// `
-	// err = db.Get(&currentBook, cidquery)
-	// if strings.HasPrefix(currentBook.ContentID, "file://") {
-	// 	currentBook.ContentID = currentBook.ContentID[len("file://"):]
-	// 	log.Println("Stripped file:// from ContentID")
-	// 	log.Println("Current Book ContentID:", currentBook.ContentID)
-	// }
-	//
-	// if err != nil {
-	// 	log.Fatal("Error getting last opened ContentID:", err)
-	// }
-	//
 	// err = db.Select(&currentBook.Bookmarks, `
 	// 	SELECT
 	// 		b.BookmarkID,
@@ -417,6 +391,12 @@ func init() {
 		log.Fatalf("Failed to create kscribbler database: %v", err)
 	}
 	fmt.Println("Kscribbler init done")
+
+	err = populateKscribblerDBBook()
+	if err != nil {
+		log.Fatalf("Failed to populate kscribbler database: %v", err)
+	}
+	fmt.Println("Kscribbler populate done")
 
 }
 

--- a/cmd/kscribbler/main.go
+++ b/cmd/kscribbler/main.go
@@ -92,6 +92,7 @@ func (book *Book) koboToHardcover() {
 		log.Println("Raw response:\n", string(rawResp))
 		log.Fatalf("Failed to unmarshal response: %v", err)
 	}
+	fmt.Printf("Hardcover response: %+v\n", findBookResp)
 
 	if len(findBookResp.Data.Books) < 1 || len(findBookResp.Data.Books[0].Editions) < 1 {
 		log.Printf(
@@ -103,7 +104,7 @@ func (book *Book) koboToHardcover() {
 
 		// set the hardcover info in the book struct for later use
 		book.HardcoverID = findBookResp.Data.Books[0].ID
-		book.HardcoverID = findBookResp.Data.Books[0].Editions[0].ID
+		book.HardcoverEdition = findBookResp.Data.Books[0].Editions[0].ID
 	}
 
 }

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -71,6 +71,8 @@ func (book *Book) SetIsbnFromBook() bool {
 			" ", "",
 			"-", "",
 			"isbn", "",
+			"isbns", "",
+			":", "",
 			"(", "",
 			")", "",
 			"e-book", "",

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -59,13 +59,13 @@ func (book *Book) SetIsbnFromBook() bool {
 			continue
 		}
 
-		var isbnCanidate string
+		var isbnCandidate string
 		if bm.Type == "note" {
-			isbnCanidate = strings.TrimSpace(bm.Annotation.String)
+			isbnCandidate = strings.TrimSpace(bm.Annotation.String)
 		} else {
-			isbnCanidate = strings.TrimSpace(bm.Quote.String)
+			isbnCandidate = strings.TrimSpace(bm.Quote.String)
 		}
-		isbnCanidate = strings.ToLower(isbnCanidate)
+		isbnCandidate = strings.ToLower(isbnCandidate)
 
 		var isbnCleaner = strings.NewReplacer(
 			" ", "",

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -48,7 +48,7 @@ type Response struct {
 	} `json:"data"`
 }
 
-// Attempts to extract an ISBN from the book's highlights (if it is a highlighted ISBN) or notes beginning with `kscrib:`. Returns true if an ISBN was found and set
+// SetIsbnFromBook attempts to extract an ISBN from the book's highlights (if it is a highlighted ISBN) or notes beginning with `kscrib:`. Returns true if an ISBN was found and set
 func (book *Book) SetIsbnFromBook() bool {
 	isbn10Regex := regexp.MustCompile(`[0-9][-0-9]{8,12}[0-9Xx]`)
 	isbn13Regex := regexp.MustCompile(`97[89][-0-9]{10,16}`)

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"database/sql"
+	"log"
+	"regexp"
+	"strings"
 
 	"github.com/GianniBYoung/simpleISBN"
 )
@@ -13,12 +16,12 @@ type Hardcover struct {
 
 // Represents a book entry from KoboReader.sqlite
 type Book struct {
-	BookID string         `db:"book_id"`
-	Title  sql.NullString `db:"title"`
-	//TODO: check this
-	ISBN      simpleISBN.ISBN `db:"isbn"`
-	Bookmarks []Bookmark
-	Hardcover Hardcover
+	BookID     string         `db:"book_id"`
+	Title      sql.NullString `db:"title"`
+	FoundISBN  sql.NullString `db:"isbn"`
+	SimpleISBN simpleISBN.ISBN
+	Bookmarks  []Bookmark
+	Hardcover  Hardcover
 }
 
 // Represents the KoboReader.sqlite for a quote or annotation.
@@ -45,4 +48,77 @@ type Response struct {
 			Errors *string `json:"errors"`
 		} `json:"insert_reading_journal"`
 	} `json:"data"`
+}
+
+// Attempts to extract an ISBN from the book's highlights (if it is a highlighted ISBN) or notes beginning with `kscrib:`.
+func (book *Book) SetIsbnFromBook() (error, bool) {
+	isbn10Regex := regexp.MustCompile(`[0-9][-0-9]{8,12}[0-9Xx]`)
+	isbn13Regex := regexp.MustCompile(`97[89][-0-9]{10,16}`)
+
+	for _, bm := range book.Bookmarks {
+		if !bm.Annotation.Valid ||
+			!strings.Contains(bm.Annotation.String, strings.ToLower("kscrib:")) {
+			continue
+		}
+
+		var isbnCanidate string
+		if bm.Type == "note" {
+			isbnCanidate = strings.TrimSpace(bm.Annotation.String)
+		} else {
+			isbnCanidate = strings.TrimSpace(bm.Quote.String)
+		}
+		isbnCanidate = strings.ToLower(isbnCanidate)
+
+		var isbnCleaner = strings.NewReplacer(
+			" ", "",
+			"-", "",
+			"isbn", "",
+			"(", "",
+			")", "",
+			"e-book", "",
+			"ebook", "",
+			"kscrib:", "",
+			"electronic", "",
+			"book", "",
+		)
+		isbnCanidate = isbnCleaner.Replace(isbnCanidate)
+
+		// Ignore if the highlight is very long (user probably highlighted a sentence)
+		if len(isbnCanidate) > 55 {
+			continue
+		}
+
+		var isbn *simpleISBN.ISBN
+		var err error
+		var match string
+		log.Println("Checking for ISBN in: ", isbnCanidate)
+		if isbn13Regex.MatchString(isbnCanidate) {
+			log.Println("Found ISBN-13")
+			match = isbn13Regex.FindString(isbnCanidate)
+		} else if isbn10Regex.MatchString(isbnCanidate) {
+			log.Println("Found ISBN-10")
+			match = isbn10Regex.FindString(isbnCanidate)
+		} else {
+			continue
+		}
+		log.Println(match)
+
+		isbn, err = simpleISBN.NewISBN(match)
+		if err != nil {
+			log.Fatalf("ISBN matched from highlight/note but failed to parse:\n%s\n%s", match, err)
+		}
+		book.SimpleISBN = *isbn
+
+		// update the book table with the new isbn
+		updateString := "UPDATE book SET isbn = ? WHERE id LIKE ?;"
+		_, err = koboDB.Exec(updateString, isbn.ISBN13Number, "%"+book.BookID+"%")
+		log.Println("Updating content table with ISBN ->", isbn.ISBN13Number)
+
+		if err != nil {
+			log.Printf("Failed to update ISBN for book: %v", err)
+			return err, true
+		}
+
+	}
+	return nil, false
 }

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -22,23 +22,22 @@ type Hardcover struct {
 
 // Represents a book entry from KoboReader.sqlite
 type Book struct {
-	ContentID string         `db:"ContentID"`
-	Title     sql.NullString `db:"Title"`
-	KoboISBN  sql.NullString `db:"ISBN"`
-	ISBN      simpleISBN.ISBN
+	BookID string         `db:"book_id"`
+	Title  sql.NullString `db:"title"`
+	//TODO: check this
+	ISBN      simpleISBN.ISBN `db:"isbn"`
 	Bookmarks []Bookmark
 	Hardcover Hardcover
 }
 
 // Represents the KoboReader.sqlite for a quote or annotation.
 type Bookmark struct {
-	BookmarkID         string         `db:"BookmarkID"`
-	ContentID          string         `db:"ContentID"`
-	Quote              sql.NullString `db:"Text"`
-	Annotation         sql.NullString `db:"Annotation"`
-	Type               string         `db:"Type"`
-	ChapterTitle       sql.NullString `db:"ChapterTitle"`
-	KscribblerUploaded bool           `db:"KscribblerUploaded"`
+	BookmarkID         string         `db:"bookmark_id"`
+	BookID             string         `db:"book_id"`
+	Quote              sql.NullString `db:"quote"`
+	Annotation         sql.NullString `db:"annotation"`
+	Type               string         `db:"type"`
+	KscribblerUploaded bool           `db:"kscribbler_uploaded"`
 }
 
 // http response structure supporting books and reading journal insertions for hardcover.app

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -48,8 +48,8 @@ type Response struct {
 	} `json:"data"`
 }
 
-// Attempts to extract an ISBN from the book's highlights (if it is a highlighted ISBN) or notes beginning with `kscrib:`.
-func (book *Book) SetIsbnFromBook() (error, bool) {
+// Attempts to extract an ISBN from the book's highlights (if it is a highlighted ISBN) or notes beginning with `kscrib:`. Returns true if an ISBN was found and set
+func (book *Book) SetIsbnFromBook() bool {
 	isbn10Regex := regexp.MustCompile(`[0-9][-0-9]{8,12}[0-9Xx]`)
 	isbn13Regex := regexp.MustCompile(`97[89][-0-9]{10,16}`)
 
@@ -103,7 +103,8 @@ func (book *Book) SetIsbnFromBook() (error, bool) {
 
 		isbn, err = simpleISBN.NewISBN(match)
 		if err != nil {
-			log.Fatalf("ISBN matched from highlight/note but failed to parse:\n%s\n%s", match, err)
+			log.Printf("ISBN matched from highlight/note but failed to parse:\n%s\n%s", match, err)
+			return false
 		}
 		book.SimpleISBN = *isbn
 
@@ -113,12 +114,12 @@ func (book *Book) SetIsbnFromBook() (error, bool) {
 		log.Println("Updating content table with ISBN ->", isbn.ISBN13Number)
 
 		if err != nil {
-			log.Printf("Failed to update ISBN for book: %v", err)
-			return err, true
+			log.Printf("Failed to update kscribblerDB ISBN for %s: %v", book.Title.String, err)
+			return false
 		}
 
 	}
-	return nil, false
+	return true
 }
 
 // Print info about the book and its bookmarks

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -9,19 +10,16 @@ import (
 	"github.com/GianniBYoung/simpleISBN"
 )
 
-type Hardcover struct {
-	BookID    int
-	EditionID int
-}
-
 // Represents a book entry from KoboReader.sqlite
 type Book struct {
-	BookID     string         `db:"book_id"`
-	Title      sql.NullString `db:"title"`
-	FoundISBN  sql.NullString `db:"isbn"`
-	SimpleISBN simpleISBN.ISBN
-	Bookmarks  []Bookmark
-	Hardcover  Hardcover
+	BookID           string         `db:"book_id"`
+	Title            sql.NullString `db:"book_title"`
+	FoundISBN        sql.NullString `db:"isbn"`
+	SimpleISBN       simpleISBN.ISBN
+	Bookmarks        []Bookmark
+	HardcoverID      int `db:"hardcover_id"`
+	HardcoverEdition int `db:"hardcover_edition"`
+	PendingQuotes    int `db:"pending_quotes"`
 }
 
 // Represents the KoboReader.sqlite for a quote or annotation.
@@ -121,4 +119,36 @@ func (book *Book) SetIsbnFromBook() (error, bool) {
 
 	}
 	return nil, false
+}
+
+// Print info about the book and its bookmarks
+func (book Book) String() string {
+	var result string
+
+	result += "\n========== Book ==========\n"
+	result += fmt.Sprintf("Title: %s\n", book.Title.String)
+	result += fmt.Sprintf("BookID: %s\n", book.BookID)
+	result += fmt.Sprintf("ISBN: %s", book.SimpleISBN.String())
+
+	result += "\n===== Hardcover Info =====\n"
+	result += fmt.Sprintf("HardcoverID: %d\n", book.HardcoverID)
+	result += fmt.Sprintf("EditionID: %d\n", book.HardcoverEdition)
+
+	result += "\n======== Bookmarks ========\n"
+	for i, bm := range book.Bookmarks {
+		result += fmt.Sprintf("[%d]\n", i+1)
+		result += fmt.Sprintf("BookmarkID: %s\n", bm.BookmarkID)
+		result += fmt.Sprintf("Type: %s\n", bm.Type)
+
+		if bm.Quote.Valid {
+			result += fmt.Sprintf("Quote: %s\n", bm.Quote.String)
+		}
+		if bm.Annotation.Valid {
+			result += fmt.Sprintf("Annotation: %s\n", bm.Annotation.String)
+		}
+
+		result += "--------------------------\n"
+	}
+
+	return result
 }

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -79,23 +79,23 @@ func (book *Book) SetIsbnFromBook() bool {
 			"electronic", "",
 			"book", "",
 		)
-		isbnCanidate = isbnCleaner.Replace(isbnCanidate)
+		isbnCandidate = isbnCleaner.Replace(isbnCandidate)
 
 		// Ignore if the highlight is very long (user probably highlighted a sentence)
-		if len(isbnCanidate) > 55 {
+		if len(isbnCandidate) > 55 {
 			continue
 		}
 
 		var isbn *simpleISBN.ISBN
 		var err error
 		var match string
-		log.Println("Checking for ISBN in: ", isbnCanidate)
-		if isbn13Regex.MatchString(isbnCanidate) {
+		log.Println("Checking for ISBN in: ", isbnCandidate)
+		if isbn13Regex.MatchString(isbnCandidate) {
 			log.Println("Found ISBN-13")
-			match = isbn13Regex.FindString(isbnCanidate)
-		} else if isbn10Regex.MatchString(isbnCanidate) {
+			match = isbn13Regex.FindString(isbnCandidate)
+		} else if isbn10Regex.MatchString(isbnCandidate) {
 			log.Println("Found ISBN-10")
-			match = isbn10Regex.FindString(isbnCanidate)
+			match = isbn10Regex.FindString(isbnCandidate)
 		} else {
 			continue
 		}

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -6,18 +6,9 @@ import (
 	"github.com/GianniBYoung/simpleISBN"
 )
 
-type PrivacyLevel int
-
-const (
-	PrivacyPublic    PrivacyLevel = 1
-	PrivacyFollowers PrivacyLevel = 2
-	PrivacyPrivate   PrivacyLevel = 3
-)
-
 type Hardcover struct {
-	BookID       int
-	EditionID    int
-	PrivacyLevel PrivacyLevel
+	BookID    int
+	EditionID int
 }
 
 // Represents a book entry from KoboReader.sqlite

--- a/cmd/kscribbler/structs.go
+++ b/cmd/kscribbler/structs.go
@@ -110,7 +110,7 @@ func (book *Book) SetIsbnFromBook() bool {
 
 		// update the book table with the new isbn
 		updateString := "UPDATE book SET isbn = ? WHERE id LIKE ?;"
-		_, err = koboDB.Exec(updateString, isbn.ISBN13Number, "%"+book.BookID+"%")
+		_, err = kscribblerDB.Exec(updateString, isbn.ISBN13Number, "%"+book.BookID+"%")
 		log.Println("Updating content table with ISBN ->", isbn.ISBN13Number)
 
 		if err != nil {

--- a/packaging/KoboRoot/etc/udev/rules.d/98-kscribbler.rules
+++ b/packaging/KoboRoot/etc/udev/rules.d/98-kscribbler.rules
@@ -1,2 +1,0 @@
-KERNEL=="eth*", ACTION=="add", RUN+="/opt/bin/kscribbler"
-KERNEL=="wlan*", ACTION=="add", RUN+="/opt/bin/kscribbler"

--- a/packaging/KoboRoot/mnt/onboard/.adds/nm/kscribbler
+++ b/packaging/KoboRoot/mnt/onboard/.adds/nm/kscribbler
@@ -1,3 +1,1 @@
-menu_item:reader:Kscribbler Sync:nickel_misc:rescan_books
-  chain_success:cmd_spawn:quiet:sleep 15
-  chain_success:cmd_spawn:quiet:/opt/bin/kscribbler >> /mnt/onboard/.adds/kscribbler/kscribbler.log 2>&1
+menu_item:reader:Kscribbler Sync:cmd_spawn:quiet:/opt/bin/kscribbler >> /mnt/onboard/.adds/kscribbler/kscribbler.log 2>&1


### PR DESCRIPTION
Trying to piggyback of the KoboReader.sqlite database caused massive headache, uncertainty and timing issues depending on when changes were commited to it. 

I initially wanted to make as minimal modifications to the device as I could and try to hook into the native ecosystem but that was just hard and limiting. 

This release moves to an internal database and removes some scope that was never fully fleshed out and working. 

Much more flexibility and potential has been gained here.